### PR TITLE
fix the nullable tag generation to comply with openapi 3.0

### DIFF
--- a/lib/swagger_yard/swagger.rb
+++ b/lib/swagger_yard/swagger.rb
@@ -167,10 +167,7 @@ module SwaggerYard
         unless h['$ref']
           h["description"] = prop.description if prop.description && !prop.description.strip.empty?
           if prop.nullable
-            h["x-nullable"] = true
-            if h["type"]
-              h["type"] = [h["type"], "null"]
-            end
+            h["nullable"] = true
           end
           h["example"] = prop.example if prop.example
         end

--- a/spec/lib/swagger_yard/swagger_spec.rb
+++ b/spec/lib/swagger_yard/swagger_spec.rb
@@ -276,8 +276,7 @@ RSpec.describe SwaggerYard::Swagger do
       context "with a nullable flag" do
         let(:content) { ['@model MyModel', '@property name(nullable) [string]  Name'] }
 
-        its(['name', 'type'])           { is_expected.to eq(['string', 'null']) }
-        its(['name', 'x-nullable'])     { is_expected.to eq(true) }
+        its(['name', 'nullable'])       { is_expected.to eq(true) }
       end
 
       context "with a nullable model" do


### PR DESCRIPTION
the gem currently generates nullable properties like:


```
"candidate_ref": {
            "type": [
              "string",
              "null"
            ],
            "x-nullable": true,
            "example": "cand123ref"
          }
          
```

this is wrong but openapi 3.0 standard https://swagger.io/docs/specification/data-models/data-types/ 

the right format should be:

```
type: integer
nullable: true
```